### PR TITLE
update version of marathon image from v1.2.0-RC6 (unavailable) to v1.3.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "2181:2181"
   mesos-master:
-    image: mesosphere/marathon:v1.2.0-RC6
+    image: mesosphere/marathon:v1.3.0
     hostname: mesos-master
     entrypoint: [ "mesos-master" ]
     ports:
@@ -45,7 +45,7 @@ services:
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
   marathon:
-    image: mesosphere/marathon:v1.2.0-RC6
+    image: mesosphere/marathon:v1.3.0
     ports:
      - "8080:8080"
     links:


### PR DESCRIPTION
For whatever reason, mesosphere/marathon:v1.2.0-RC6 no longer available on DockerHub.
Changed to  1.3.0.  Tested that the sample service comes up healthy as expected.