### PR TITLE
docker-compose v3 w/ custom network subnet 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,59 +1,94 @@
-version: '2'
+version: "3"
+
 services:
   zookeeper:
     image: netflixoss/exhibitor:1.5.2
     hostname: zookeeper
     ports:
       - "2181:2181"
+    networks:
+      app_net:
+        ipv4_address: 172.16.121.2
+
   mesos-master:
-    image: mesosphere/marathon:v1.3.10
-    hostname: mesos-master
-    entrypoint: [ "mesos-master" ]
+    image: mesosphere/mesos-master:1.2.1
+    privileged: true
+    hostname: localhost
     ports:
       - "5050:5050"
+    networks:
+      app_net:
+        ipv4_address: 172.16.121.3
     links:
       - zookeeper
+    depends_on:
+      - zookeeper
     environment:
-      - MESOS_CLUSTER=local
-      - MESOS_HOSTNAME=mesos-master.docker
-      - MESOS_LOG_DIR=/var/log
-      - MESOS_WORK_DIR=/var/lib/mesos
-      - MESOS_QUORUM=1
-      - MESOS_ZK=zk://zookeeper:2181/mesos
+      MESOS_ZK: zk://zookeeper:2181/mesos
+      MESOS_QUORUM: 1
+      MESOS_CLUSTER: docker-compose
+#      MESOS_REGISTRY: replicated_log # default is in_memory for some reason
+      MESOS_HOSTNAME: localhost
+      MESOS_WORK_DIR: /var/tmp/mesos
+      MESOS_LOG_DIR: /var/log/mesos
+      LIBPROCESS_IP: 172.16.121.3
+
+
   mesos-slave:
-    image: mesosphere/mesos-slave-dind:0.2.4_mesos-1.0.1_docker-1.12.1_ubuntu-14.04.5
-    entrypoint:
-      - mesos-slave
+    image: mesosphere/mesos-slave:1.2.1
     privileged: true
-    hostname: mesos-slave
+    hostname: localhost
     ports:
       - "5051:5051"
+    networks:
+      app_net:
+        ipv4_address: 172.16.121.4
     links:
+      - zookeeper:zookeeper
+      - mesos-master:master.mesos
+    depends_on:
       - zookeeper
       - mesos-master
     environment:
-      - MESOS_CONTAINERIZERS=docker,mesos
-      - MESOS_ISOLATOR=cgroups/cpu,cgroups/mem
-      - MESOS_LOG_DIR=/var/log
-      - MESOS_MASTER=zk://zookeeper:2181/mesos
-      - MESOS_PORT=5051
-      - MESOS_WORK_DIR=/var/lib/mesos
-      - MESOS_EXECUTOR_REGISTRATION_TIMEOUT=5mins
-      - MESOS_EXECUTOR_SHUTDOWN_GRACE_PERIOD=90secs
-      - MESOS_DOCKER_STOP_TIMEOUT=60secs
-      - MESOS_RESOURCES=cpus:2;mem:2048;disk:20480;ports(*):[12000-12999]
+      MESOS_MASTER: zk://zookeeper:2181/mesos
+      MESOS_CONTAINERIZERS: docker
+      MESOS_PORT: 5051
+      MESOS_RESOURCES: ports(*):[11000-11999]
+      MESOS_HOSTNAME: localhost
+      MESOS_WORK_DIR: /var/tmp/mesos
+      MESOS_LOG_DIR: /var/log/mesos
+      LIBPROCESS_IP: 172.16.121.4
     volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock"
+      - /var/run/docker.sock:/var/run/docker.sock
+
   marathon:
     image: mesosphere/marathon:v1.3.10
+    entrypoint:
+      - ./bin/start
+      - --disable_ha
     hostname: localhost
     ports:
      - "8080:8080"
+    networks:
+      app_net:
+        ipv4_address: 172.16.121.5
     links:
       - zookeeper
       - mesos-master
-    extra_hosts:
-      - "mesos-slave:172.17.0.1"
+    depends_on:
+      - zookeeper
+      - mesos-master
+      - mesos-slave
     environment:
       - MARATHON_ZK=zk://zookeeper:2181/marathon
       - MARATHON_MASTER=zk://zookeeper:2181/mesos
+      - LIBPROCESS_IP=172.16.121.5
+
+networks:
+  app_net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      -
+        subnet: 172.16.121.0/24


### PR DESCRIPTION
I've built on your example today and got it to work. The trick was to set `LIBPROCESS_IP` correctly. For that I had to use static IP Addresses. To avoid conflicts I used a custom subnet, different than the default one.

Summarizing the main changes:
- [x] Upgraded Mesos to `1.2.1`
- [x] Marathon starts with `--disable_ha`
- [x] Custom subnet w/ static IP Addresses 
- [x] Docker Compose `v3`